### PR TITLE
feat: add :noweb-ref support for Org mode babel Elisp blocks

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -717,9 +717,9 @@ let
         }
         (stringToCharacters text)).acc;
 
-  # Run tokenizeElisp' on all Elisp code blocks (with `:tangle yes`
-  # set) from an Org mode babel text. If the block doesn't have a
-  # `tangle` attribute, it's determined by `defaultArgs`.
+  # Run tokenizeElisp' on all Elisp code blocks from an Org mode babel text.
+  # Includes blocks with `:tangle yes` OR `:noweb-ref` attribute.
+  # If a block doesn't have a `tangle` attribute, it's determined by `defaultArgs`.
   tokenizeOrgModeBabelElisp' = let
     isElisp = lib.flip elem [ "elisp" "emacs-lisp" ];
     doTangle = lib.flip elem [ "yes" ''"yes"'' ];
@@ -731,7 +731,8 @@ let
             let
               tangle = toLower (block.flags.":tangle" or defaultArgs.":tangle" or "no");
               language = toLower block.language;
-            in isElisp language && doTangle tangle)
+              hasNowebRef = block.flags ? ":noweb-ref";
+            in isElisp language && (doTangle tangle || hasNowebRef))
           (parseOrgModeBabel text);
       in
         foldl'


### PR DESCRIPTION
## Summary

Add support for including Elisp code blocks with `:noweb-ref` attribute in `tokenizeOrgModeBabelElisp'`.

Relative Issue: https://github.com/nix-community/emacs-overlay/issues/354

## Changes

- Include Elisp code blocks that have `:noweb-ref` attribute, even without `:tangle yes`
- Update comments to reflect the new inclusion criteria

## Motivation

In Org mode's literate programming workflow, `:noweb-ref` is used to name code blocks for inclusion via noweb syntax (`<<block-name>>`).
These blocks are essential for tangling but may not have `:tangle yes` set directly.

This change ensures that code blocks with `:noweb-ref` are properly tokenized and included in the output.

## Test

```console
$ nix-instantiate --eval --strict -E '
  let
    lib = import ./default.nix {};

    # Simulate literate config pattern
    testOrg = "
  * Package Configuration

  ** Evil Mode
  #+begin_src elisp :noweb-ref packages
  (use-package evil
    :ensure t
    :config
    (evil-mode 1))
  #+end_src

  ** Magit
  #+begin_src elisp :noweb-ref packages
  (use-package magit
    :ensure t)
  #+end_src

  ** Main Config
  #+begin_src elisp :tangle yes :noweb yes
  <<packages>>
  #+end_src
  ";

  in {
    parsed = lib.fromOrgModeBabelElisp testOrg;
    blockCount = builtins.length (lib.fromOrgModeBabelElisp testOrg);
  }
  '

{ blockCount = 3; parsed = [ [ "use-package" "evil" ":ensure" true ":config" [ "evil-mode" 1 ] ] [ "use-package" "magit" ":ensure" true ] "<<packages>>" ]; }

$
```
